### PR TITLE
Strip shortdesc of any newlines.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ else:
 
 setup(
     name='Colr',
-    version='0.9.1',
+    version='0.9.2',
     author='Christopher Welborn',
     author_email='cj@welbornprod.com',
     packages=['colr'],

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 shortdesc = 'Easy terminal colors, with chainable methods.'
 try:
     with open('DESC.txt', 'r') as f:
-        shortdesc = f.read()
+        shortdesc = f.read().strip()
 except FileNotFoundError:
     pass
 


### PR DESCRIPTION
I ran into a problem with installing this package, because a newer version of setuptools was enforcing that no newlines exist in the `description` parameter.  This trivial patch should fix the issue.